### PR TITLE
define UTF8 encoding, build fail otherwise. ASCII assumed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
+					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Lors de la construction du projet par maven, une erreur est reportée
"src/main/java/fr/treeptik/conf/UserAdministration.java:[28,34] error: unmappable character for encoding ASCII"

Il s'agit d'un accent dans le fichier.
